### PR TITLE
Add stringviews, concat, and slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ GC-managed array) as UTF-8, WTF-8, or WTF-16, depending on the source
 language's needs.  For example Java usually wants to treat strings as
 WTF-16 code unit sequences, so Java would encode to WTF-16.  This
 proposal provides facilities for measuring how many bytes an encoding
-would take, and actually doing the encoding.
+would take, and for actually doing the encoding.
 
 As a possibly post-MVP feature we also would also like to provide the
 ability to get a WTF-8 or WTF-16 "view" on a string, which should
@@ -761,11 +761,22 @@ against known strings, we know how long of a slice to take.
 
 Which version of `ends-with-howdy?` will a source language produce?
 They are essentially equivalent in this use case of comparing against a
-static string, but in the general case, a source language that process
+static string, but in the general case, a source language that processes
 strings in terms of codepoints would probably use the iterator,
 languages that treat strings as UTF-8 sequences would produce the WTF-8
 version whereas those that process strings in terms of 16-bit code units
 will compile to the WTF-16 version.
+
+One could instead do a character-by-character comparison, to avoid
+creating the slice.
+
+Stepping back a bit, prefix and suffix checks are examples of operations
+for which the stringref proposal should facilitate high-performance
+implementations.  The primary strategy of the stringref proposal is to
+allow any such operation to be build in terms of its primitives.
+However if there are important compound operations (e.g. prefix/suffix
+checks) that can be sped up with a dedicated instruction, we should be
+open to considering adding more instructions.
 
 ### Store a `stringref` without copying
 

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ sequence.  Return 0 otherwise.
 ```
 (string.is_usv_sequence str:stringref)
   -> bool:i32
-``
+```
 Return 1 if the string *`str`* is a sequence of unicode scalar values,
 and 0 otherwise.  A 0 result indicates that *`str`* contains isolated
 surrogates.

--- a/README.md
+++ b/README.md
@@ -380,8 +380,8 @@ The maximum number of bytes returned by these instructions is
 the contents can't be encoded at all (the return value is -1).
 
 ```
-(string.encode_utf8 $memory str:stringref ptr:address)
-(string.encode_wtf8 $memory str:stringref ptr:address)
+wtf8_policy ::= 'utf8' | 'wtf8' | 'replace'
+(string.encode_wtf8 $memory $wtf8_policy str:stringref ptr:address)
 (string.encode_wtf16 $memory str:stringref ptr:address)
 ```
 Encode the contents of the string *`str`* as UTF-8, WTF-8, or WTF-16,
@@ -393,6 +393,13 @@ Note that no `NUL` terminator is ever written.  For
 The maximum number of bytes that can be encoded at once by
 `string.encode` is 2<sup>31</sup>-1.  If an encoding would require more
 bytes, it is as if the codepoints can't be encoded (a trap).
+
+For `string.encode_wtf8`, if an isolated surrogate is seen, the behavior
+determines on the *`$wtf8_policy`* immediate.  For `utf8`, trap.  For
+`wtf8`, the surrogate is encoded as per WTF-8.  For `replace`, `U+FFFD`
+(the replacement character) is encoded instead.  Note that the UTF-8
+encoding of `U+FFFD` is the same length as the encoding of an isolated
+surrogate.
 
 ### Concatenation
 
@@ -465,8 +472,7 @@ may allow for 64-bit variants of the position-using instructions, which
 could relax this restriction.)
 
 ```
-policy ::= 'utf8' | 'wtf8' | 'replace'
-(stringview_wtf8.encode $memory $policy view:stringview_wtf8 ptr:address pos:i32 bytes:i32)
+(stringview_wtf8.encode $memory $wtf8_policy view:stringview_wtf8 ptr:address pos:i32 bytes:i32)
   -> next_pos:i32, bytes:i32
 ```
 Write a subsequence of the WTF-8 encoding of *`view`* to memory at
@@ -485,8 +491,7 @@ may allow for 64-bit variants of the position-using instructions, which
 could relax this restriction.)
 
 If an isolated surrogate is seen, the behavior determines on the
-*`$policy`* immediate.  For `utf8`, trap.  For `wtf8`, the surrogate is
-encoded as per WTF-8.  For `replace`, `U+FFFD` is encoded instead.
+*`$wtf8_policy`* immediate, as in `string.encode_wtf8`.
 
 ```
 (stringview_wtf8.slice view:stringview_wtf8 start:i32 end:i32)


### PR DESCRIPTION
As discussed in https://github.com/wingo/stringrefs/issues/31, this
update separates out two halves of the proposal: a basic "stringref"
facility and an encoding-specific "views" facility.  The basic
stringrefs work with whole strings.  The views can denote positions in
strings, measure encoded sizes for substrings, and take slices.  The
"iterator" view is actually stateful and closer to the original opaque
cursor design.

Also update scope to include concatenation and slice.

Update goals to reflect that we win when we can get a good solution for
many languages, not just C++ -- so no need to mention it specifically.